### PR TITLE
Migrate test projects to .Net 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - develop
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,19 +12,14 @@ on:
 
 jobs:
   build:
-    # target 18.04 due to netcoreapp2.0 requiring OpenSSL 1.0 and newer versions of Ubuntu shipping with OpenSSL 1.1
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core SDK '2.0'
+      - name: Setup .NET Core SDK '5.0'
         uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: '2.0.x'
-      - name: Setup .NET Core SDK '3.1'
-        uses: actions/setup-dotnet@v1.7.2
-        with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '5.0.x'
       - name: Install dependencies
         run: dotnet restore
       - name: Plugin Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   build:
-    # target 18.04 due to netcoreapp2.0 requiring OpenSSL 1.0 and newer versions of Ubuntu shipping with OpenSSL 1.1
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
-  build:
+  package-and-release:
     runs-on: ubuntu-latest
 
     steps:

--- a/ADMPlugin/ADMPlugin.csproj
+++ b/ADMPlugin/ADMPlugin.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AgGatewayADAPTFramework" Version="2.4.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />
   </ItemGroup>

--- a/ADMPlugin/Serializers/VersionInfoSerializer.cs
+++ b/ADMPlugin/Serializers/VersionInfoSerializer.cs
@@ -40,7 +40,7 @@ namespace AgGateway.ADAPT.ADMPlugin.Serializers
 
       // due to a breaking change in Newtonsoft between Core 2.0 and Core 3.1+, need to handle version info that was originally emitted as a dict rather than a string.
       // 3.1+ expects the version info to be in a string format therefore we use this logic to convert to a string if the PluginVersion type is null (not a primitive type).
-      if (json["PluginVersion"].Type == null)
+      if (json["PluginVersion"] != null && json["PluginVersion"].Type == null)
       {
         var major = json["PluginVersion"].Major;
         var minor = json["PluginVersion"].Minor;

--- a/ADMPlugin/Serializers/VersionInfoSerializer.cs
+++ b/ADMPlugin/Serializers/VersionInfoSerializer.cs
@@ -36,8 +36,21 @@ namespace AgGateway.ADAPT.ADMPlugin.Serializers
       }
 
       var fileString = File.ReadAllText(filePath);
+      dynamic json = JsonConvert.DeserializeObject(fileString);
+
+      // due to a breaking change in Newtonsoft between Core 2.0 and Core 3.1+, need to handle version info that was originally emitted as a dict rather than a string.
+      // 3.1+ expects the version info to be in a string format therefore we use this logic to convert to a string if the PluginVersion type is null (not a primitive type).
+      if (json["PluginVersion"].Type == null)
+      {
+        var major = json["PluginVersion"].Major;
+        var minor = json["PluginVersion"].Minor;
+        var build = json["PluginVersion"].Build;
+        var revision = json["PluginVersion"].Revision;
+
+        json["PluginVersion"] = $"{major}.{minor}.{build}.{revision}";
+      }
             
-      var model = JsonConvert.DeserializeObject<AdmVersionInfo>(fileString);
+      var model = JsonConvert.DeserializeObject<AdmVersionInfo>(json.ToString());
       return model;
     }
   }

--- a/ADMPlugin/Serializers/VersionInfoSerializer.cs
+++ b/ADMPlugin/Serializers/VersionInfoSerializer.cs
@@ -36,21 +36,8 @@ namespace AgGateway.ADAPT.ADMPlugin.Serializers
       }
 
       var fileString = File.ReadAllText(filePath);
-      dynamic json = JsonConvert.DeserializeObject(fileString);
-
-      // due to a breaking change in Newtonsoft between Core 2.0 and Core 3.1+, need to handle version info that was originally emitted as a dict rather than a string.
-      // 3.1+ expects the version info to be in a string format therefore we use this logic to convert to a string if the PluginVersion type is null (not a primitive type).
-      if (json["PluginVersion"] != null && json["PluginVersion"].Type == null)
-      {
-        var major = json["PluginVersion"].Major;
-        var minor = json["PluginVersion"].Minor;
-        var build = json["PluginVersion"].Build;
-        var revision = json["PluginVersion"].Revision;
-
-        json["PluginVersion"] = $"{major}.{minor}.{build}.{revision}";
-      }
-            
-      var model = JsonConvert.DeserializeObject<AdmVersionInfo>(json.ToString());
+      
+      var model = JsonConvert.DeserializeObject<AdmVersionInfo>(fileString, new NetCoreApp31CompatibleVersionConverter()); 
       return model;
     }
   }

--- a/AcceptanceTest/AcceptanceTest.csproj
+++ b/AcceptanceTest/AcceptanceTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <Version>0.0.0</Version>
     <NeutralLanguage></NeutralLanguage>
     <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>

--- a/PluginTest/PluginTest.csproj
+++ b/PluginTest/PluginTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <Version>0.0.0</Version>
     <NeutralLanguage></NeutralLanguage>
     <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>

--- a/TestUtilities/TestUtilities.csproj
+++ b/TestUtilities/TestUtilities.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <Copyright>Copyright (C) 2015-19 AgGateway and ADAPT Contributors</Copyright>
     <AssemblyVersion>0.0.0.0</AssemblyVersion>
     <Version>0.0.0</Version>


### PR DESCRIPTION
This PR addresses issue #77. Due to a breaking change in NewtonSoft there was a minor change to ensure backwards compatibility when deserializing version info.