### PR TITLE
Attempting to serialize SpatialRecords more efficiently

### DIFF
--- a/ADMPlugin/ADMPlugin.csproj
+++ b/ADMPlugin/ADMPlugin.csproj
@@ -13,7 +13,7 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AgGatewayADAPTFramework" Version="2.4.0" />
+    <PackageReference Include="AgGatewayADAPTFramework" Version="2.6.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="protobuf-net" Version="2.4.0" />

--- a/ADMPlugin/Converters/ISpatialRecordConverter.cs
+++ b/ADMPlugin/Converters/ISpatialRecordConverter.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using AgGateway.ADAPT.ADMPlugin.Models;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+
+namespace AgGateway.ADAPT.ADMPlugin.Converters
+{
+    public interface ISpatialRecordConverter
+    {
+        IEnumerable<SpatialRecord> ConvertToSpatialRecords(IEnumerable<SerializableSpatialRecord> protobufSpatialRecords, IEnumerable<WorkingData> workingData);
+        IEnumerable<SerializableSpatialRecord> ConvertToSerializableSpatialRecords(IEnumerable<SpatialRecord> spatialRecords, List<WorkingData> workingData);
+    }
+}

--- a/ADMPlugin/Converters/SpatialRecordConverter.cs
+++ b/ADMPlugin/Converters/SpatialRecordConverter.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Linq;
+using AgGateway.ADAPT.ADMPlugin.Models;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
+
+namespace AgGateway.ADAPT.ADMPlugin.Converters
+{
+    public class SpatialRecordConverter
+    {
+        public static IEnumerable<SpatialRecord> ConvertToSpatialRecords(IEnumerable<SerializableSpatialRecord> protobufSpatialRecords, IEnumerable<WorkingData> workingData)
+        {
+            if (protobufSpatialRecords == null)
+            {
+                return Enumerable.Empty<SpatialRecord>();
+            }
+
+            var workingDataById = workingData.ToDictionary(meter => meter.Id.ReferenceId, meter => meter);
+
+            return protobufSpatialRecords.Select(protobufSpatialRecord => ConvertToSpatialRecord(protobufSpatialRecord, workingDataById));
+        }
+
+        private static SpatialRecord ConvertToSpatialRecord(SerializableSpatialRecord protobufSpatialRecord, Dictionary<int, WorkingData> workingDataById)
+        {
+            if (protobufSpatialRecord == null)
+            {
+                return null;
+            }
+
+            var spatialRecord = new SpatialRecord
+            {
+                Geometry = protobufSpatialRecord.Geometry,
+                Timestamp = protobufSpatialRecord.Timestamp
+            };
+            foreach (var appliedLatencyValue in protobufSpatialRecord.AppliedLatencyValues)
+            {
+                spatialRecord.SetAppliedLatency(workingDataById[appliedLatencyValue.Key], appliedLatencyValue.Value);
+            }
+
+            foreach (var enumeratedMeterValue in protobufSpatialRecord.EnumeratedMeterValues)
+            {
+                var workingData = workingDataById[enumeratedMeterValue.Key] as EnumeratedWorkingData;
+                var representation = workingData?.Representation as EnumeratedRepresentation;
+                var enumeratedValue = representation.ToInternalRepresentation().EnumerationMembers[enumeratedMeterValue.Value].ToModelEnumMember();
+                var value = new EnumeratedValue
+                {
+                    Representation = representation,
+                    Value = enumeratedValue,
+                    Code = (int?)enumeratedMeterValue.Value
+                };
+                spatialRecord.SetMeterValue(workingData, value);
+            }
+
+            foreach (var numericMeterValue in protobufSpatialRecord.NumericMeterValues)
+            {
+                var workingData = workingDataById[numericMeterValue.Key] as NumericWorkingData;
+                var representation = workingData.Representation as NumericRepresentation;
+                var numericValue = new NumericRepresentationValue
+                {
+                    Representation = representation,
+                    UserProvidedUnitOfMeasure = workingData.UnitOfMeasure,
+                    Value = new NumericValue(workingData.UnitOfMeasure, numericMeterValue.Value)
+                };
+                spatialRecord.SetMeterValue(workingData, numericValue);
+            }
+
+            // TODO: String workingData
+            // TODO: Reduce duplication
+            // TODO: What about the missing crap on these RepresentationValue objects?
+
+            return spatialRecord;
+        }
+
+        public static IEnumerable<SerializableSpatialRecord> ConvertToSerializableSpatialRecords(IEnumerable<SpatialRecord> spatialRecords, List<WorkingData> workingData)
+        {
+            if (spatialRecords == null)
+            {
+                return Enumerable.Empty<SerializableSpatialRecord>();
+            }
+
+            return spatialRecords.Select(spatialRecord => ConvertToSerializableSpatialRecord(spatialRecord, workingData));
+        }
+
+        private static SerializableSpatialRecord ConvertToSerializableSpatialRecord(SpatialRecord spatialRecord, List<WorkingData> workingData)
+        {
+            var serializableSpatialRecord = new SerializableSpatialRecord()
+            {
+                Geometry = spatialRecord.Geometry,
+                Timestamp = spatialRecord.Timestamp
+            };
+            foreach (var meter in workingData)
+            {
+                var appliedLatency = spatialRecord.GetAppliedLatency(meter);
+                if (appliedLatency.HasValue)
+                {
+                    serializableSpatialRecord.AppliedLatencyValues[meter.Id.ReferenceId] = appliedLatency;
+                }
+
+                var meterValue = spatialRecord.GetMeterValue(meter);
+                switch (meterValue)
+                {
+                    case null:
+                        break;
+                    case NumericRepresentationValue numericValue:
+                        serializableSpatialRecord.NumericMeterValues[meter.Id.ReferenceId] = numericValue.Value.Value;
+                        break;
+                    case EnumeratedValue enumeratedValue:
+                        serializableSpatialRecord.EnumeratedMeterValues[meter.Id.ReferenceId] = enumeratedValue.Value.Code;
+                        break;
+                    case StringValue stringValue:
+                        serializableSpatialRecord.StringMeterValues[meter.Id.ReferenceId] = stringValue.Value;
+                        break;
+                }
+            }
+
+            return serializableSpatialRecord;
+        }
+    }
+}

--- a/ADMPlugin/DatacardConstants.cs
+++ b/ADMPlugin/DatacardConstants.cs
@@ -15,6 +15,7 @@ namespace AgGateway.ADAPT.ADMPlugin
     public const string SectionFile = "Section{0}.adm";
     public const string WorkingDataFile = "Meter{0}.adm";
     public const string OperationDataFile = "OperationData{0}.adm";
+    public const string SpatialRecordsFile = "SpatialRecords{0}.adm";
     public const string WorkRecordFile = "WorkRecord{0}.adm";
     public const string CatalogFile = "Catalog.adm";
     public const string ProprietaryValuesFile = "ProprietaryValues.adm";

--- a/ADMPlugin/Models/SerializableSpatialRecord.cs
+++ b/ADMPlugin/Models/SerializableSpatialRecord.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+using ProtoBuf;
+
+namespace AgGateway.ADAPT.ADMPlugin.Models
+{
+    [ProtoContract]
+    public class SerializableSpatialRecord
+    {
+        public SerializableSpatialRecord()
+        {
+            AppliedLatencyValues = new Dictionary<int, int?>();
+            NumericMeterValues = new Dictionary<int, double>();
+            EnumeratedMeterValues = new Dictionary<int, long>();
+            StringMeterValues = new Dictionary<int, string>();
+        }
+
+        [ProtoMember(1)]
+        public Shape Geometry { get; set; }
+
+        [ProtoMember(2)]
+        public DateTime Timestamp { get; set; }
+
+        [ProtoMember(3)]
+        public Dictionary<int, int?> AppliedLatencyValues { get; set; }
+
+        [ProtoMember(4)]
+        public Dictionary<int, double> NumericMeterValues { get; set; }
+
+        [ProtoMember(5)]
+        public Dictionary<int, long> EnumeratedMeterValues { get; set; }
+
+        [ProtoMember(6)]
+        public Dictionary<int, string> StringMeterValues { get; set; }
+
+    }
+}

--- a/ADMPlugin/Protobuf/V2/LoggedData/SpatialRecordType.cs
+++ b/ADMPlugin/Protobuf/V2/LoggedData/SpatialRecordType.cs
@@ -1,6 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
 using ProtoBuf.Meta;
 
 namespace AgGateway.ADAPT.ADMPlugin.Protobuf.V2.LoggedData
@@ -9,9 +7,9 @@ namespace AgGateway.ADAPT.ADMPlugin.Protobuf.V2.LoggedData
   {
     public static void Configure(RuntimeTypeModel model)
     {
-      var type = model.Add(typeof(AgGateway.ADAPT.ApplicationDataModel.LoggedData.SpatialRecord), Constants.UseDefaults);
-      type.AddField(1, nameof(AgGateway.ADAPT.ApplicationDataModel.LoggedData.SpatialRecord.Geometry));
-      type.AddField(2, nameof(AgGateway.ADAPT.ApplicationDataModel.LoggedData.SpatialRecord.Timestamp));
+      var type = model.Add(typeof(SpatialRecord), Constants.UseDefaults);
+      type.AddField(1, nameof(SpatialRecord.Geometry));
+      type.AddField(2, nameof(SpatialRecord.Timestamp));
       type.AddField(3, "_meterValues");
       type.AddField(4, "_appliedLatencyValues");
     }

--- a/ADMPlugin/Serializers/DocumentsSerializer.cs
+++ b/ADMPlugin/Serializers/DocumentsSerializer.cs
@@ -255,7 +255,7 @@ namespace AgGateway.ADAPT.ADMPlugin.Serializers
 
     private void ExportSpatialRecords(IBaseSerializer baseSerializer, string documentsPath, OperationData operationData, List<WorkingData> meters)
     {
-      var fileName = string.Format(DatacardConstants.OperationDataFile, operationData.Id.ReferenceId);
+      var fileName = string.Format(DatacardConstants.SpatialRecordsFile, operationData.Id.ReferenceId);
       var filePath = Path.Combine(documentsPath, fileName);
 
       if (operationData.GetSpatialRecords == null)
@@ -437,11 +437,20 @@ namespace AgGateway.ADAPT.ADMPlugin.Serializers
 
     private void ImportSpatialRecords(IBaseSerializer baseSerializer, string documentsPath, OperationData operationData, IEnumerable<WorkingData> workingDatas)
     {
-      var spatialRecordFileName = string.Format(DatacardConstants.OperationDataFile, operationData.Id.ReferenceId);
-      var spatialRecordFilePath = Path.Combine(documentsPath, spatialRecordFileName);
+      var protobufSpatialRecordsFileName = string.Format(DatacardConstants.SpatialRecordsFile, operationData.Id.ReferenceId);
+      var protobufSpatialRecordsFilePath = Path.Combine(documentsPath, protobufSpatialRecordsFileName);
+      if (File.Exists(protobufSpatialRecordsFilePath))
+      {
+          var spatialRecords = baseSerializer.DeserializeWithLengthPrefix<SerializableSpatialRecord>(protobufSpatialRecordsFilePath);
+          operationData.GetSpatialRecords = () => _spatialRecordConverter.ConvertToSpatialRecords(spatialRecords, workingDatas);
+      }
+      else
+      {
+          var spatialRecordFileName = string.Format(DatacardConstants.OperationDataFile, operationData.Id.ReferenceId);
+          var spatialRecordFilePath = Path.Combine(documentsPath, spatialRecordFileName);
 
-      var spatialRecords = baseSerializer.DeserializeWithLengthPrefix<SerializableSpatialRecord>(spatialRecordFilePath);
-      operationData.GetSpatialRecords = () => _spatialRecordConverter.ConvertToSpatialRecords(spatialRecords, workingDatas);
+          operationData.GetSpatialRecords = () => baseSerializer.DeserializeWithLengthPrefix<SpatialRecord>(spatialRecordFilePath);
+      }
     }
 
     private string ConvertToSearchPattern(string filePattern)

--- a/AcceptanceTest/AcceptanceTest.csproj
+++ b/AcceptanceTest/AcceptanceTest.csproj
@@ -13,7 +13,7 @@
     <PackageId>AgGateway.ADAPT.AcceptanceTest</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AgGatewayADAPTFramework" Version="2.4.0" />
+    <PackageReference Include="AgGatewayADAPTFramework" Version="2.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />

--- a/PluginTest/Converters/SpatialRecordConverterTest.cs
+++ b/PluginTest/Converters/SpatialRecordConverterTest.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AgGateway.ADAPT.ADMPlugin.Converters;
+using AgGateway.ADAPT.ADMPlugin.Models;
+using AgGateway.ADAPT.ApplicationDataModel.LoggedData;
+using AgGateway.ADAPT.ApplicationDataModel.Representations;
+using AgGateway.ADAPT.ApplicationDataModel.Shapes;
+using AgGateway.ADAPT.Representation.RepresentationSystem;
+using AgGateway.ADAPT.Representation.RepresentationSystem.ExtensionMethods;
+using AgGateway.ADAPT.Representation.UnitSystem;
+using NUnit.Framework;
+using EnumeratedRepresentation = AgGateway.ADAPT.ApplicationDataModel.Representations.EnumeratedRepresentation;
+using NumericRepresentation = AgGateway.ADAPT.ApplicationDataModel.Representations.NumericRepresentation;
+
+namespace AgGateway.ADAPT.PluginTest.Converters
+{
+    [TestFixture]
+    public class SpatialRecordConverterTest
+    {
+        private SpatialRecordConverter _spatialRecordConverter;
+
+        [SetUp]
+        public void Setup()
+        {
+            _spatialRecordConverter = new SpatialRecordConverter();
+        }
+
+        [Test]
+        public void GivenNullWhenConvertToSerialThenEmptyList()
+        {
+            Assert.IsEmpty(_spatialRecordConverter.ConvertToSerializableSpatialRecords(null, new List<WorkingData>()));
+            Assert.IsEmpty(_spatialRecordConverter.ConvertToSerializableSpatialRecords(new List<SpatialRecord>(), null));
+        }
+
+        [Test]
+        public void GivenNullWhenConvertToModelThenEmptyList()
+        {
+            Assert.IsEmpty(_spatialRecordConverter.ConvertToSpatialRecords(null, new List<WorkingData>()));
+            Assert.IsEmpty(_spatialRecordConverter.ConvertToSpatialRecords(new List<SerializableSpatialRecord>(), null));
+        }
+
+        [Test]
+        public void GivenSpatialRecordsWhenConvertToSerialThenShapeAndTimeAreCopied()
+        {
+            var spatialRecord = new SpatialRecord
+            {
+                Geometry = new Point { X = 1.23, Y = 4.56 },
+                Timestamp = DateTime.Now
+            };
+            var result = MapSingle(spatialRecord, new List<WorkingData>());
+
+            Assert.AreSame(spatialRecord.Geometry, result.Geometry);
+            Assert.AreEqual(spatialRecord.Timestamp, result.Timestamp);
+        }
+
+        [Test]
+        public void GivenSpatialRecordsWhenConvertToSerialThenEnumeratedValuesAreConverted()
+        {
+            var workingData = new EnumeratedWorkingData
+            {
+                Representation = RepresentationInstanceList.dtHeaderStatus.ToModelRepresentation()
+            };
+            var value = new EnumeratedValue
+            {
+                Representation = (EnumeratedRepresentation)workingData.Representation,
+                Value = DefinedTypeEnumerationInstanceList.dtiHeaderStatusOff.ToModelEnumMember()
+            };
+            var spatialRecord = new SpatialRecord();
+            spatialRecord.SetMeterValue(workingData, value);
+
+            var result = MapSingle(spatialRecord, new List<WorkingData> {workingData});
+
+            Assert.AreEqual(value.Value.Code, result.EnumeratedMeterValues[workingData.Id.ReferenceId]);
+        }
+
+        [Test]
+        public void GivenSpatialRecordsWhenConvertToSerialThenNumericValuesAreConvertedWithSameUnit()
+        {
+            var workingData = new NumericWorkingData
+            {
+                Representation = RepresentationInstanceList.vrFuelAmount.ToModelRepresentation(),
+                UnitOfMeasure = UnitSystemManager.GetUnitOfMeasure("l")
+            };
+            var value = new NumericRepresentationValue((NumericRepresentation) workingData.Representation,
+                new NumericValue(UnitSystemManager.GetUnitOfMeasure("m3"), 1));
+            var spatialRecord = new SpatialRecord();
+            spatialRecord.SetMeterValue(workingData, value);
+
+            var result = MapSingle(spatialRecord, new List<WorkingData> { workingData });
+
+            // 1 cubic meter is 1000 liters. We expect the value was converted to the unit of measure that is on the WorkingData.
+            Assert.AreEqual(1000, result.NumericMeterValues[workingData.Id.ReferenceId], Double.Epsilon);
+        }
+
+        [Test]
+        public void GivenWorkingDataWithNoUnitWhenConvertToSerialThenUnitIsCopiedFromSpatialRecord()
+        {
+            var workingData = new NumericWorkingData
+            {
+                Representation = RepresentationInstanceList.vrFuelAmount.ToModelRepresentation(),
+                UnitOfMeasure = null
+            };
+            var value = new NumericRepresentationValue((NumericRepresentation) workingData.Representation,
+                new NumericValue(UnitSystemManager.GetUnitOfMeasure("l"), 1));
+            var spatialRecord = new SpatialRecord();
+            spatialRecord.SetMeterValue(workingData, value);
+
+            MapSingle(spatialRecord, new List<WorkingData> { workingData });
+
+            Assert.AreEqual("l", workingData.UnitOfMeasure.Code);
+        }
+
+        [Test]
+        public void GivenSpatialRecordsWhenConvertToSerialThenStringValuesAreCopied()
+        {
+            var workingData = new EnumeratedWorkingData();
+            var value = new StringValue { Value = "some value" };
+            var spatialRecord = new SpatialRecord();
+            spatialRecord.SetMeterValue(workingData, value);
+
+            var result = MapSingle(spatialRecord, new List<WorkingData> { workingData });
+
+            Assert.AreEqual(value.Value, result.StringMeterValues[workingData.Id.ReferenceId]);
+        }
+
+        [Test]
+        public void GivenSpatialRecordsWhenConvertToSerialThenAppliedLatencyIsCopied()
+        {
+            var workingData = new NumericWorkingData();
+            var latency = 14;
+            var spatialRecord = new SpatialRecord();
+            spatialRecord.SetAppliedLatency(workingData, latency);
+
+            var result = MapSingle(spatialRecord, new List<WorkingData> { workingData });
+
+            Assert.AreEqual(latency, result.AppliedLatencyValues[workingData.Id.ReferenceId]);
+        }
+
+        private SerializableSpatialRecord MapSingle(SpatialRecord spatialRecord, List<WorkingData> workingData)
+        {
+            var spatialRecords = new[] { spatialRecord };
+            return _spatialRecordConverter.ConvertToSerializableSpatialRecords(spatialRecords, workingData).Single();
+        }
+    }
+}

--- a/PluginTest/PluginTest.csproj
+++ b/PluginTest/PluginTest.csproj
@@ -13,7 +13,7 @@
     <PackageId>AgGateway.ADAPT.PluginTest</PackageId>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AgGatewayADAPTFramework" Version="2.4.0" />
+    <PackageReference Include="AgGatewayADAPTFramework" Version="2.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />

--- a/PluginTest/Serializers/DocumentsSerializerTest.cs
+++ b/PluginTest/Serializers/DocumentsSerializerTest.cs
@@ -166,7 +166,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
 
       _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
-      var expectedFileName = String.Format(DatacardConstants.OperationDataFile, operationData.Id.ReferenceId);
+      var expectedFileName = String.Format(DatacardConstants.SpatialRecordsFile, operationData.Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
 
       _baseSerializerMock.Verify(s => s.SerializeWithLengthPrefix(new List<SerializableSpatialRecord>(), expectedPath), Times.Once);

--- a/PluginTest/Serializers/DocumentsSerializerTest.cs
+++ b/PluginTest/Serializers/DocumentsSerializerTest.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using AgGateway.ADAPT.ADMPlugin;
+using AgGateway.ADAPT.ADMPlugin.Converters;
+using AgGateway.ADAPT.ADMPlugin.Models;
 using AgGateway.ADAPT.ADMPlugin.Serializers;
 using AgGateway.ADAPT.ApplicationDataModel.ADM;
 using AgGateway.ADAPT.ApplicationDataModel.Documents;
@@ -18,6 +20,8 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
     private string _path;
     private Documents _documents;
     private Mock<IBaseSerializer> _baseSerializerMock;
+    private Mock<ISpatialRecordConverter> _spatialRecordConverterMock;
+    private DocumentsSerializer _documentsSerializer;
 
     [SetUp]
     public void Setup()
@@ -25,6 +29,9 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       _documents = new Documents { LoggedData = new List<LoggedData>() };
       _path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
       _baseSerializerMock = new Mock<IBaseSerializer>();
+      _spatialRecordConverterMock = new Mock<ISpatialRecordConverter>();
+
+      _documentsSerializer = new DocumentsSerializer(_spatialRecordConverterMock.Object);
     }
 
     [Test]
@@ -33,8 +40,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var loggedDatas = new List<LoggedData> { new LoggedData() };
       _documents.LoggedData = loggedDatas;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.LoggedDataFile, loggedDatas[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -47,8 +53,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var guidanceAllocations = new List<GuidanceAllocation> { new GuidanceAllocation() };
       _documents.GuidanceAllocations = guidanceAllocations;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.GuidanceAllocationFile, guidanceAllocations[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -61,8 +66,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var plans = new List<Plan> { new Plan() };
       _documents.Plans = plans;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.PlanFile, plans[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -75,8 +79,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var recommendations = new List<Recommendation> { new Recommendation() };
       _documents.Recommendations = recommendations;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.RecommendationFile, recommendations[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -89,8 +92,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var summaries = new List<Summary> { new Summary() };
       _documents.Summaries = summaries;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.SummaryFile, summaries[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -103,8 +105,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var workItemOperations = new List<WorkItemOperation> { new WorkItemOperation() };
       _documents.WorkItemOperations = workItemOperations;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.WorkItemOperationFile, workItemOperations[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -117,8 +118,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var workItems = new List<WorkItem> { new WorkItem() };
       _documents.WorkItems = workItems;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.WorkItemFile, workItems[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -131,8 +131,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
       var workOrders = new List<WorkOrder> { new WorkOrder() };
       _documents.WorkOrders = workOrders;
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.WorkOrderFile, workOrders[0].Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
@@ -142,8 +141,7 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
     [Test]
     public void GivenNullDocumentsWhenExportDocumentsThenDoesNothing()
     {
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, null, _path);
+        _documentsSerializer.Serialize(_baseSerializerMock.Object, null, _path);
 
       _baseSerializerMock.Verify(s => s.Serialize(It.IsAny<object>(), It.IsAny<string>()), Times.Never);
     }
@@ -166,13 +164,12 @@ namespace AgGateway.ADAPT.PluginTest.Serializers
                 }
             };
 
-      var documentsSerializer = new DocumentsSerializer();
-      documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
+      _documentsSerializer.Serialize(_baseSerializerMock.Object, _documents, _path);
 
       var expectedFileName = String.Format(DatacardConstants.OperationDataFile, operationData.Id.ReferenceId);
       var expectedPath = Path.Combine(_path, DatacardConstants.DocumentsFolder, expectedFileName);
 
-      _baseSerializerMock.Verify(s => s.SerializeWithLengthPrefix(new List<SpatialRecord>(), expectedPath), Times.Once);
+      _baseSerializerMock.Verify(s => s.SerializeWithLengthPrefix(new List<SerializableSpatialRecord>(), expectedPath), Times.Once);
     }
 
     [TearDown]


### PR DESCRIPTION
**This probably needs more testing! Opened PR for critique and conversation while continuing to test.**

Based on the test data I've used so far, this results in an overall data size on disk that is roughly 1/3rd of the original. This was achieved by removing as much metadata as possible from the SpatialRecord's.

- Do not serialize Representation objects inside SpatialRecord's. These should already exist on WorkingData.Representation.
- Do not serialize UnitOfMeasure objects inside SpatialRecord's. These should already exist on WorkingData.Representation (and if they don't, we can copy them there). Note: If the UnitOfMeasure for a particular WorkingData changes partway through the SpatialRecord's, we convert to keep the unit consistent. This requires we maintain the same class of unit. It will break if WorkingData.UnitOfMeasure is kilograms and the associated NumericRepresentationValue.UnitOfMeasure is meters.
- Change the file containing SpatialRecords from OperationData{0}.adm to SpatialRecords{0}.adm. This lets us look for the new filename and, if it exists, deserialize to the new object (else do what we did before for backwards compatibility). 