### PR TITLE
fix: update Newtonsoft.Json constraint

### DIFF
--- a/AgGatewayADMPlugin.nuspec
+++ b/AgGatewayADMPlugin.nuspec
@@ -13,7 +13,7 @@
     <tags>aggateway adapt adm agriculture</tags>
     <dependencies>
       <dependency id="AgGatewayADAPTFramework" version="[2.0.2,4)" />
-      <dependency id="Newtonsoft.Json" version="[12,13)" />
+      <dependency id="Newtonsoft.Json" version="[13,14)" />
       <dependency id="protobuf-net" version="[2.4,3)" />
     </dependencies>
     <references>


### PR DESCRIPTION
The project's nuspec file was constrained to Newtonsoft 12, but the plugin itself depends on 13. The constraint was added at a time that version 12 was in use but this has since changed. With the constraint in place, projects that use the ADMPlugin as a dependency can run into issues resolving unrelated dependencies. This PR updates the constraint to reflect that ADMPlugin uses Newtonsoft 13.